### PR TITLE
Add procedure for deploying to AUR when not on Archlinux

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ These packages can easily be installed by using one of the [AUR helpers](https:/
 
 1. Update `zividVersion` in `scripts/generate_all_pkgbuilds.sh`
 2. Run the tests. See [azure-pipelines.yml](azure-pipelines.yml).
-3. Run `./scripts/update_aur.sh`.
+3. Make sure you have an AUR account with write access to the zivid repo and SSH public key.
+4. Run `./scripts/update_aur.sh`.
 
 ## Registering new packages
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ schedules:
 jobs:
 - job: Linux
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-20.04
   strategy:
     matrix:
       ArchLinux:
@@ -22,4 +22,10 @@ jobs:
               bash -c "./setup.sh &&
                        ./lint.sh &&
                        ./test.sh"
-    displayName: 'Build and test'
+    displayName: 'Build, lint and test on Archlinux'
+- job: BuildDeploymentImage
+  pool:
+    vmImage: ubuntu-20.04
+  steps:
+  - script: docker build -t arch-deployment -f deployment/Dockerfile .
+    displayName: 'Test building of deployment image '

--- a/continuous-integration/lint.sh
+++ b/continuous-integration/lint.sh
@@ -20,6 +20,6 @@ black --check --diff "$pythonFiles" || exit $?
 
 echo Running shellcheck on:
 echo "$bashFiles"
-shellcheck -e SC1090,SC2086,SC2046 $bashFiles || exit $?
+shellcheck -x -e SC1090,SC2086,SC2046 $bashFiles || exit $?
 
 echo Success! ["$0"]

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -1,0 +1,18 @@
+FROM archlinux/archlinux:base
+
+# Run setup script
+COPY continuous-integration/setup.sh .
+RUN ./setup.sh
+
+# Additional packages needed for deployment
+RUN pacman -Syu --noconfirm --needed git openssh
+ 
+# Add user for deployment
+RUN useradd -ms /bin/bash deploymentuser
+USER deploymentuser
+
+# Copy entire build context into the container
+COPY . /home/deploymentuser/zivid-arch-linux-pkgbuild-generator
+
+# Set workdir to repo root
+WORKDIR /home/deploymentuser/zivid-arch-linux-pkgbuild-generator

--- a/scripts/update_aur.sh
+++ b/scripts/update_aur.sh
@@ -1,24 +1,39 @@
 #!/bin/bash
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT_DIR=$(realpath "$SCRIPT_DIR/..")
 
-TMP_DIR=$(mktemp --tmpdir --directory zivid-aur-update-XXXX)
-BUILD_DIR=$TMP_DIR/build
-GIT_DIR=$TMP_DIR/git
+source /etc/os-release || exit $?
 
-$SCRIPT_DIR/generate_all_pkgbuilds.sh $BUILD_DIR || exit $?
+if [ $ID != "arch" ]; then
+    # If not on Arch, build Docker image and re-run this script inside container
+    docker build -t arch-deployment -f ${ROOT_DIR}/deployment/Dockerfile . || exit $?
+    docker run --rm \
+        --volume ~/.ssh:/home/deploymentuser/.ssh \
+        --volume ~/.gitconfig:/home/deploymentuser/.gitconfig \
+        -it arch-deployment \
+        "$0" "$@"
+else
+    # This block only works on Arch
+    TMP_DIR=$(mktemp --tmpdir --directory zivid-aur-update-XXXX)
+    BUILD_DIR=$TMP_DIR/build
+    GIT_DIR=$TMP_DIR/git
 
-mkdir -p $GIT_DIR || exit $?
-cd $GIT_DIR || exit $?
-for packageDir in "$BUILD_DIR"/*; do
-    package=$(basename $packageDir)
-    git clone ssh://aur@aur.archlinux.org/$package.git || exit $?
-    pushd $package || exit $?
-    cp $packageDir/* . || exit $?
-    pkgver=$(grep pkgver PKGBUILD |cut -d"'" -f2)
-    makepkg --printsrcinfo > .SRCINFO || exit $?
-    git add $(ls -A) || exit $?
-    git commit -m"Version $pkgver"
-    git push --set-upstream origin master || exit $?
-    popd || exit $?
-done
+    $SCRIPT_DIR/generate_all_pkgbuilds.sh $BUILD_DIR || exit $?
+
+    mkdir -p $GIT_DIR || exit $?
+    cd $GIT_DIR || exit $?
+    for packageDir in "$BUILD_DIR"/*; do
+        package=$(basename $packageDir)
+        git clone ssh://aur@aur.archlinux.org/$package.git || exit $?
+        pushd $package || exit $?
+        cp $packageDir/* . || exit $?
+        pkgver=$(grep pkgver PKGBUILD |cut -d"'" -f2)
+        makepkg --printsrcinfo > .SRCINFO || exit $?
+        git add $(ls -A) || exit $?
+        git commit -m"Version $pkgver"
+        git push --set-upstream origin master || exit $?
+        popd || exit $?
+    done
+fi
+


### PR DESCRIPTION
The current instructions in the README for deploying to AUR only work if
you are on Archlinux yourself. If you are on a different distro like
Ubuntu, the deployment must be done from within an Archlinux based
Docker container. This can be a bit of a hassle to set up, so this
commit adds a procedure for automating most of that.

Specifically this commit adds:
- A Dockerfile that defines an image that can be used for deployment.
- Instructions in README for how to use the image for deployment.
- New CI job for testing that the image can be successfully built.