### PR TITLE
Fix unpacking zstd compressed archive

### DIFF
--- a/PKGBUILD.in
+++ b/PKGBUILD.in
@@ -20,5 +20,5 @@ sha256sums=({sha256sum})
 options=(!strip)
 
 package() {{
-    bsdtar -xf data.tar.*z -C "${{pkgdir}}"
+    bsdtar -xf data.tar.* -C "${{pkgdir}}"
 }}


### PR DESCRIPTION
SDK 2.11 uses zstd compression for its debian packages. This requires a slight adjustment to the PKGBUILD.