### PR TITLE
Bump Zivid SDK version to 2.12.0

### DIFF
--- a/continuous-integration/setup.sh
+++ b/continuous-integration/setup.sh
@@ -8,6 +8,7 @@ fi
 
 pacman -Syu --noconfirm --needed \
        awk \
+       debugedit \
        fakeroot \
        file \
        flake8 \

--- a/continuous-integration/test.sh
+++ b/continuous-integration/test.sh
@@ -12,10 +12,6 @@ fi
 
 sudo -u nobody $ROOT_DIR/scripts/generate_all_pkgbuilds.sh $TMP_DIR || exit $?
 
-function test_zivid-telicam-driver {
-    [[ -f /opt/TeliCamSDK/lib/libTeliCamApi_64.so ]] || exit 1
-}
-
 function test_zivid {
     [[ -f /usr/lib/libZividCore.so ]] || exit 1
 }
@@ -44,7 +40,6 @@ function test_package {
     test_$package || exit $?
 }
 
-test_package zivid-telicam-driver || exit $?
 test_package zivid || exit $?
 test_package zivid-studio || exit $?
 test_package zivid-tools || exit $?

--- a/scripts/generate_all_pkgbuilds.sh
+++ b/scripts/generate_all_pkgbuilds.sh
@@ -4,7 +4,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR=$(realpath "$SCRIPT_DIR/..")
 VENV=$(mktemp --tmpdir --directory zivid-pkgbuild-build-env-XXXX) || exit $?
 
-zividVersion=2.11.1+de9b5dae-1
+zividVersion=2.12.0+6afd4961-1
 zividPackages="zivid zivid-studio zivid-tools zivid-genicam"
 
 if [ -z "$1" ]; then
@@ -33,8 +33,6 @@ pip install --no-cache-dir -r $ROOT_DIR/requirements.txt || exit $?
 for zividPackage in $zividPackages; do
     generate $zividVersion $zividPackage $zividVersion || exit $?
 done
-
-generate $zividVersion zivid-telicam-driver 3.0.1.1-3 || exit $?
 
 deactivate || exit $?
 

--- a/scripts/generate_pkgbuild.py
+++ b/scripts/generate_pkgbuild.py
@@ -24,16 +24,14 @@ class Pkgbuild:
     description = "Defining the Future of 3D Machine Vision"
 
     dependencies = {
-        "zivid-telicam-driver": (),
-        "zivid": ("zivid-telicam-driver", "opencl-driver"),
+        "zivid": ("opencl-driver",),
         "zivid-studio": ("zivid",),
         "zivid-tools": ("zivid",),
         "zivid-genicam": ("zivid",),
     }
 
     replaces = {
-        "zivid-telicam-driver": ("zivid-telicam-sdk",),
-        "zivid": (),
+        "zivid": ("zivid-telicam-driver",),
         "zivid-studio": (),
         "zivid-tools": (),
         "zivid-genicam": (),


### PR DESCRIPTION
In this release the zivid-telicam-driver package is removed.