### PR TITLE
Update GitHub Actions to use Ubuntu 24.04 for deployment image build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
           ./lint.sh
           ./test.sh
   build-deployment-image:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
       - name: Test building of deployment image


### PR DESCRIPTION
Ubuntu 20.04 runners were removed.